### PR TITLE
スポット詳細画面の実装とフロントエンドの改善

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -27,3 +27,6 @@ import './handle_files.js';
 import './spot_drag.js';
 import './spot_form_submission.js';
 import './image_validation.js';
+import 'lightbox2';
+import 'lightbox2/dist/css/lightbox.css';
+import 'lightbox2/dist/js/lightbox.min.js';

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -18,3 +18,4 @@
 @import 'form_styles';
 @import 'spots';
 @import 'spot_images';
+@import 'spot_details';

--- a/app/javascript/stylesheets/spot_details.scss
+++ b/app/javascript/stylesheets/spot_details.scss
@@ -1,0 +1,59 @@
+.container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 20px;
+}
+
+.spot-details {
+  background: #ffffff;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+}
+
+.spot-detail-section {
+  margin-bottom: 30px;
+}
+
+.spot-title {
+  font-size: 2em;
+  color: #333;
+  margin-bottom: 10px;
+}
+
+.section-title {
+  font-size: 1.5em;
+  color: #555;
+  margin-bottom: 15px;
+}
+
+.spot-description {
+  font-size: 1em;
+  line-height: 1.6;
+  color: #666;
+}
+
+.spot-gallery {
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+}
+
+.gallery-row {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 15px;
+}
+
+.gallery-item {
+  overflow: hidden;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.spot-image {
+  width: 100%;
+  height: auto;
+  object-fit: contain;
+  max-height: 200px;
+}

--- a/app/javascript/stylesheets/styles.scss
+++ b/app/javascript/stylesheets/styles.scss
@@ -10880,7 +10880,7 @@ p {
 #mainNav {
   padding-top: 1rem;
   padding-bottom: 1rem;
-  /* background-color: #212529; */
+  background-color: #8EB8FF;
 }
 #mainNav .navbar-toggler {
   padding: 0.75rem;
@@ -11320,4 +11320,8 @@ section#contact form#contactForm :-ms-input-placeholder {
 
 .container {
   margin-top: 120px;
+}
+
+.navbar {
+  position: relative;
 }

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -1,32 +1,29 @@
-<div class="container-fiuld"> 
-  <div class="row">
-      <div class="col-md-12">
-          <div class="spot-view-box">
-              <div class="update-content">
-                  <div class="row">
-                      <label class="col-md-3" for="name">スポット名</label>
-                      <div class="col-md-9">
-                        <%= link_to @spot.name %>
-                      </div>
-                  </div>
+<div class="container">
+  <div class="spot-details">
+    <div class="spot-detail-section">
+      <h2 class="spot-title"><%= @spot.name %></h2>
+    </div>
+
+    <div class="spot-detail-section">
+      <h3 class="section-title">スポット詳細</h3>
+      <p class="spot-description"><%= @spot.description %></p>
+    </div>
+
+    <div class="spot-detail-section">
+      <h3 class="section-title">スポット画像</h3>
+      <div class="spot-gallery">
+        <% @spot.images.each_slice(5) do |images| %>
+          <div class="gallery-row">
+            <% images.each do |image| %>
+              <div class="gallery-item">
+                <a href="<%= image.name.url %>" data-lightbox="spot-images" data-title="<%= image.description %>">
+                  <%= image_tag image.name.url, class: 'spot-image' %>
+                </a>
               </div>
-              <div class="update-content">
-                  <div class="row">
-                      <label class="col-md-3" for="start_date">スポット詳細</label>
-                      <div class="col-md-9"><%= @spot.description %></div>
-                  </div>
-              </div>
-              <div class="update-content">
-                  <div class="row">
-                      <label class="col-md-3" for="end_date">スポット画像</label>
-                      <div class="col-md-9">
-                        <%= @spot.images.each do  |image| %>
-                          <%= image_tag image.name.url %>
-                        <% end %>
-                      </div>
-                  </div>
+            <% end %>
           </div>
+        <% end %>
       </div>
+    </div>
   </div>
 </div>
-

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -16,7 +16,7 @@
           <div class="gallery-row">
             <% images.each do |image| %>
               <div class="gallery-item">
-                <a href="<%= image.name.url %>" data-lightbox="spot-images" data-title="<%= image.description %>">
+                <a href="<%= image.name.url %>" data-lightbox="spot-images">
                   <%= image_tag image.name.url, class: 'spot-image' %>
                 </a>
               </div>

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@rails/webpacker": "4.3.0",
     "bootstrap": "^5.3.2",
     "jquery": "^3.7.1",
+    "lightbox2": "^2.11.5",
     "popper.js": "^1.16.1",
     "sweetalert2": "^11.12.4",
     "turbolinks": "^5.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4568,6 +4568,11 @@ last-call-webpack-plugin@^3.0.0:
     lodash "^4.17.5"
     webpack-sources "^1.1.0"
 
+lightbox2@^2.11.5:
+  version "2.11.5"
+  resolved "https://registry.yarnpkg.com/lightbox2/-/lightbox2-2.11.5.tgz#440543a9561224551f559e6e9249d72485435c78"
+  integrity sha512-IsDqv/D9pjgh7GvwTNvmHF98+nrIcOD17fraXgtx8ivq469y95l5ycLi6SeZAZHdeyD3cGLjYwbDX8SRfWx5fA==
+
 lines-and-columns@^1.1.6:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"


### PR DESCRIPTION
## 概要
* スポット詳細ページのUIと機能の改善を行いました。
* Lightbox2を使用して画像の拡大表示機能を追加し、より直感的に画像を閲覧できるようにしました。
* CSSの整理と追加により、ユーザー体験を向上させました。

## 変更点の詳細
### 新機能の追加
#### 画像拡大表示機能:
* Lightbox2を導入し、画像をクリックすると拡大して表示できるようにしました。
* application.js に Lightbox2 の JavaScript と CSS をインポートしました。
* <a> タグに data-lightbox="spot-images" 属性を追加することで、複数画像をスライドショー形式で閲覧できるようにしました。

### スタイルとレイアウトの改善
#### スポット詳細ページのスタイル調整:
* CSSを利用して詳細ページに洗練されたレイアウトを提供。
* 全体のコンテナに最大幅とパディングを設定し、スポット詳細セクションに背景色、パディング、ボーダーを追加。
* 画像ギャラリーは5列のグリッドレイアウトに配置し、各アイテムにボーダーとシャドウを付けてスタイルを強化。
* application.scss に新規スタイルを追加してインポート。

### コードのリファクタリング
#### 不要なコードの整理
* 画像リンクに設定されていた data-title 属性を削除し、シンプルにしました。
* CSSとHTML構造を整理し、不要なクラスや属性を削除。