### PR TITLE
スポット投稿機能の改善

### DIFF
--- a/app/javascript/packs/spot_drag.js
+++ b/app/javascript/packs/spot_drag.js
@@ -1,15 +1,10 @@
 import { handleFiles } from './handle_files';
 
 $(document).on('turbolinks:load', function() {
-  function handleDrop(event) {
-    event.preventDefault();
-    const files = event.originalEvent.dataTransfer.files;
-    if (files.length) {
-      handleFiles(files, $('#previews .input').first(), $('#previews .input').first().find('.upload-label'));
-    }
-  }
-
   const dropArea = $('#previews');
+
+  // ドラッグ関連のイベントを解除して重複を防ぐ
+  dropArea.off('dragover dragleave drop');
 
   dropArea.on('dragover', function(event) {
     event.preventDefault();
@@ -23,5 +18,11 @@ $(document).on('turbolinks:load', function() {
     dropArea.removeClass('drag-over');
   });
 
-  dropArea.on('drop', handleDrop);
+  dropArea.on('drop', function(event) {
+    event.preventDefault();
+    const files = event.originalEvent.dataTransfer.files;
+    if (files.length) {
+      handleFiles(files, $('#previews .input').first(), $('#previews .input').first().find('.upload-label'));
+    }
+  });
 });

--- a/app/javascript/packs/spot_form_submission.js
+++ b/app/javascript/packs/spot_form_submission.js
@@ -8,7 +8,11 @@ $(document).on('turbolinks:load', function() {
     const $submitButton = $spotForm.find('input[type="submit"]');
     
     if ($submitButton.length) {
-      $submitButton.on('click', function(event) {
+      // 既存の 'click' イベントを解除して重複を防ぐ
+      $submitButton.off('click.formSubmissionNamespace');
+
+      // 新たに 'click' イベントをバインド
+      $submitButton.on('click.formSubmissionNamespace', function(event) {
         event.preventDefault(); // フォーム送信をキャンセル
 
         // 1. 画像のバリデーション

--- a/app/javascript/packs/spot_images.js
+++ b/app/javascript/packs/spot_images.js
@@ -5,5 +5,9 @@ $(document).on('turbolinks:load', function() {
     handleFiles(e.target.files, $(this).closest('li'), $(this).closest('.upload-label'));
   }
 
-  $(document).on('change', '.image_upload', handleImageChange);
+  // 既存の 'change' イベントを解除して重複を防ぐ
+  $(document).off('change.imageUploadNamespace', '.image_upload');
+
+  // 新たに 'change' イベントをバインド
+  $(document).on('change.imageUploadNamespace', '.image_upload', handleImageChange);
 });

--- a/app/javascript/packs/spot_preview_delete.js
+++ b/app/javascript/packs/spot_preview_delete.js
@@ -1,5 +1,9 @@
 $(document).on('turbolinks:load', function() {
-  $(document).on('click', '.image-preview__btn_delete', function() {
+  // 既存の 'click' イベントを解除して重複を防ぐ
+  $(document).off('click.imagePreviewNamespace', '.image-preview__btn_delete');
+
+  // 新たに 'click' イベントをバインド
+  $(document).on('click.imagePreviewNamespace', '.image-preview__btn_delete', function() {
     const append_input = $(`
       <li class="input">
         <label class="upload-label">


### PR DESCRIPTION
## 概要
* off メソッドで既存のイベントを解除し、新たなイベントが発火しても重複しないように変更。
* 名前空間を使用してイベントリスナーの管理を容易にした。

## 変更点の詳細
* off メソッドをイベントリスナーのバインド前に追加し、既存のイベントを解除することで、画像の複数表示などの問題を解決。
* 各イベントリスナーに名前空間を追加し、特定のイベントのみが適切に管理されるように改善。
imageUploadNamespace: 画像アップロード関連のイベントに対して適用。
imagePreviewNamespace: 画像プレビュー削除に関するイベントに対して適用。
formSubmissionNamespace: フォーム送信に関連するイベントに対して適用。