### PR TITLE
スポット編集機能の実装とフロントエンドの改善

### DIFF
--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -24,7 +24,20 @@ class SpotsController < ApplicationController
   end
 
   def edit
+    @spot = current_user.spots.find(spot_params)
   end
+
+  def update
+    @spot = current_user.spots.build(spot_params)
+    if @spot.update(spot_params)
+      flash[:notice] = t('defaults.message.spot_update')
+      redirect_to @spot
+    else
+      flash.now[:danger] = t('defaults.message.invalid')
+      render :edit
+    end
+  end
+
 
   private
 

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -1,4 +1,9 @@
 class SpotsController < ApplicationController
+  before_action :authenticate_user!, except: [:index, :show]
+
+  before_action :set_spot, only: [:show, :edit, :update]
+  before_action :require_owner!, only: [:edit, :update]
+
   def index
     @spots = Spot.all
   end
@@ -20,15 +25,12 @@ class SpotsController < ApplicationController
   end
 
   def show
-    @spot = Spot.find(params[:id])
   end
 
   def edit
-    @spot = current_user.spots.find(spot_params)
   end
 
   def update
-    @spot = current_user.spots.build(spot_params)
     if @spot.update(spot_params)
       flash[:notice] = t('defaults.message.spot_update')
       redirect_to @spot
@@ -40,6 +42,17 @@ class SpotsController < ApplicationController
 
 
   private
+
+  def set_spot
+    @spot = Spot.find(params[:id])
+  end
+
+  def require_owner!
+    unless @spot.user_id == current_user.id
+      flash[:alert] = t('defaults.message.spot_not_owner')
+      redirect_to root_path
+    end
+  end
 
   def spot_params
     params.require(:spot).permit(:name, :description, images_attributes: [:id, :name, :name_cache, :_destroy])

--- a/app/javascript/packs/handle_files.js
+++ b/app/javascript/packs/handle_files.js
@@ -1,65 +1,78 @@
+let newImageCounter = 100;
+// 例: ここからスタート。既存が何枚あってもぶつからないように
+// もっと大きい値にしてもOK
+
+export function buildNewInputLi() {
+  // 新しい画像を追加する度にカウンタをインクリメント
+  newImageCounter++;
+
+  // “newImageCounter” をそのまま form-index に使う
+  return $(`
+    <li class="input" data-file-type="new">
+      <label class="upload-label">
+        <div class="upload-label__text">
+          ドラッグアンドドロップ<br>またはクリックしてファイルをアップロード
+        </div>
+        <div class="input-area">
+          <input
+            class="hidden image_upload"
+            type="file"
+            name="spot[images_attributes][${newImageCounter}][name]"
+            data-form-index="${newImageCounter}"
+            data-file-type="new"
+          >
+        </div>
+      </label>
+    </li>
+  `);
+}
+
+// handleFiles: ファイル選択後にプレビューを作る
 export function handleFiles(files, $li, $label) {
   const $ul = $('#previews');
-  const $inputs = $ul.find('.image_upload');
+  const $inputLi = $li; // 今回ファイルを選んだ <li class="input">
 
-  $.each(files, function(index, file) {
+  $.each(files, function(i, file) {
+    // FileReader で読み込み
+    const reader = new FileReader();
+
+    // プレビュー用 DOM
     const preview = $(`
       <div class="image-preview__wrapper">
-        <img class="preview">
+        <!-- 新規追加なので data-file-type="new" とする -->
+        <img class="preview" data-file-type="new">
         <div class="image-preview__btn">
           <div class="image-preview__btn_delete"></div>
         </div>
       </div>
     `);
 
-    const append_input = $(`
-      <li class="input">
-        <label class="upload-label">
-          <div class="upload-label__text">
-            ドラッグアンドドロップ<br>またはクリックしてファイルをアップロード
-          </div>
-          <div class="input-area">
-            <input class="hidden image_upload" type="file" name="spot[images_attributes][${index}][name]">
-          </div>
-        </label>
-      </li>
-    `);
-
-    const reader = new FileReader();
-    reader.readAsDataURL(file);
-    reader.onload = function(event) {
-      $(preview).find('.preview').attr('src', event.target.result);
+    reader.onload = function(e) {
+      preview.find('img.preview').attr('src', e.target.result);
     };
 
     reader.onloadend = function() {
-      $li.append(preview);
+      // もともとの <li class="input"> 内にプレビューを差し込む
+      $inputLi.append(preview);
+
+      // もうアップロードラベルは不要なので隠す/削除する
       $label.hide();
-      $li.removeClass('input').addClass('image-preview');
+      $inputLi.removeClass('input').addClass('image-preview');
 
-      const $lis = $ul.find('.image-preview');
-
-      if ($lis.length < 10) {
-        if ($ul.find('.input').length === 0) {
-          $ul.append(append_input);
+      // 10枚制限チェック
+      const $visiblePreviews = $ul.find('.image-preview:visible');
+      const count = $visiblePreviews.length;
+      if (count < 10) {
+        // まだ10枚未満なら、新しい空の <li class="input"> があるか確認
+        if ($ul.find('li.input').length === 0) {
+          $ul.append(buildNewInputLi());
         }
+      } else {
+        // 10枚に達したら、追加できないように既存の input を消す
+        $ul.find('li.input').remove();
       }
-
-      $inputs.each(function(index, input) {
-        $(input).attr('name', `spot[images_attributes][${index}][name]`);
-      });
-
-      adjustInputWidth($lis);
     };
-  });
-}
 
-export function adjustInputWidth($lis) {
-  const $lastLi = $('#previews li:last-child');
-  if ($lis.length == 5) {
-    $lastLi.css('width', '100%');
-  } else if ($lis.length < 5) {
-    $lastLi.css('width', `calc(100% - (20% * ${$lis.length}))`);
-  } else if ($lis.length > 5 && $lis.length < 10) {
-    $lastLi.css('width', `calc(100% - (20% * (${$lis.length} - 5)))`);
-  }
+    reader.readAsDataURL(file);
+  });
 }

--- a/app/javascript/packs/image_validation.js
+++ b/app/javascript/packs/image_validation.js
@@ -1,12 +1,19 @@
 export function validateSpotImages() {
   const $imageUploads = $('.image_upload');
+  const $existingImages = $('.existing-spot-image:visible'); // 既存の画像を取得
   let hasImage = false;
-  
+
+  // 新規画像の選択チェック
   $imageUploads.each(function() {
     if (this.files.length > 0) {
       hasImage = true;
     }
   });
+
+  // 既存画像がある場合、hasImage を true に設定
+  if ($existingImages.length > 0) {
+    hasImage = true;
+  }
 
   return hasImage;
 }

--- a/app/javascript/packs/spot_images.js
+++ b/app/javascript/packs/spot_images.js
@@ -1,13 +1,11 @@
 import { handleFiles } from './handle_files';
 
 $(document).on('turbolinks:load', function() {
-  function handleImageChange(e) {
-    handleFiles(e.target.files, $(this).closest('li'), $(this).closest('.upload-label'));
-  }
-
-  // 既存の 'change' イベントを解除して重複を防ぐ
   $(document).off('change.imageUploadNamespace', '.image_upload');
 
-  // 新たに 'change' イベントをバインド
-  $(document).on('change.imageUploadNamespace', '.image_upload', handleImageChange);
+  $(document).on('change.imageUploadNamespace', '.image_upload', function(e) {
+    const $li = $(this).closest('li');
+    const $label = $(this).closest('.upload-label');
+    handleFiles(e.target.files, $li, $label);
+  });
 });

--- a/app/javascript/packs/spot_preview_delete.js
+++ b/app/javascript/packs/spot_preview_delete.js
@@ -1,45 +1,33 @@
+import { buildNewInputLi } from './handle_files';
+
 $(document).on('turbolinks:load', function() {
-  // 既存の 'click' イベントを解除して重複を防ぐ
-  $(document).off('click.imagePreviewNamespace', '.image-preview__btn_delete');
-
-  // 新たに 'click' イベントをバインド
-  $(document).on('click.imagePreviewNamespace', '.image-preview__btn_delete', function() {
-    const append_input = $(`
-      <li class="input">
-        <label class="upload-label">
-          <div class="upload-label__text">
-            ドラッグアンドドロップ<br>またはクリックしてファイルをアップロード
-            <div class="input-area">
-              <input class="hidden image_upload" type="file">
-            </div>
-          </div>
-        </label>
-      </li>
-    `);
-
+  $(document).on('click', '.image-preview__btn_delete', function() {
     const $ul = $('#previews');
     const $li = $(this).closest('.image-preview');
 
-    $li.remove();
+    // 既存 or 新規 を判定
+    const fileType = $li.data('file-type');
+    if (fileType === 'existing') {
+      // 既存画像（DB保存済み）の場合: _destroy=true をONにして削除
+      $li.find('.hidden-destroy-field').prop('checked', true);
+      // DOMは残すが表示だけ消す
+      $li.hide();
+    } else {
+      // 新規（まだDBにない）場合は DOM ごと削除
+      $li.remove();
+    }
 
-    const $lis = $ul.find('.image-preview');
-    if ($lis.length <= 4) {
-      $('#previews li:last-child').css({
-        'width': `calc(100% - (20% * ${$lis.length}))`
-      });
-    } else if ($lis.length == 5) {
-      $('#previews li:last-child').css({
-        'width': `100%`
-      });
-    } else if ($lis.length < 9) {
-      $('#previews li:last-child').css({
-        'width': `calc(100% - (20% * (${$lis.length} - 5)))`
-      });
-    } else if ($lis.length == 9) {
-      $ul.append(append_input);
-      $('#previews li:last-child').css({
-        'width': `calc(100% - (20% * (${$lis.length} - 5)))`
-      });
+    // 残っている「表示中の画像数」を数える
+    const visibleCount = $ul.find('.image-preview:visible').length;
+    if (visibleCount < 10) {
+      // input が無ければ1つ追加
+      if ($ul.find('li.input').length === 0) {
+        // buildNewInputLi() を呼んで統一した構造を追加する
+        $ul.append(buildNewInputLi());
+      }
+    } else {
+      // 10枚以上なら input を削除
+      $ul.find('li.input').remove();
     }
   });
 });

--- a/app/javascript/stylesheets/spot_images.scss
+++ b/app/javascript/stylesheets/spot_images.scss
@@ -6,7 +6,8 @@
   list-style: none;
   border: 2px dashed #ccc;
   min-height: 156px;
-  width: 946px;
+  max-width: 946px;
+  width: 100%;
   background-color: #EEFFFF;
   display: flex;
   flex-wrap: wrap;
@@ -20,6 +21,7 @@
   flex: 1 1 calc(20% - 10px);
   max-width: 20%;
   box-sizing: border-box;
+  position: relative;
 }
 
 .upload-label__text {
@@ -42,7 +44,8 @@
   background-color: white;
 }
 
-.image-preview__wrapper .preview {
+.image-preview__wrapper .preview,
+.existing-spot-image {
   max-width: 100%;
   max-height: 100%;
   object-fit: contain;
@@ -57,13 +60,14 @@
   justify-content: center;
   border: 1px solid #ccc;
   background-color: white;
+  box-sizing: border-box;
 }
-
 
 .image-preview__btn {
   position: absolute;
-  top: 0;
-  left: 0;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   width: 100%;
   height: 100%;
   display: flex;
@@ -72,6 +76,7 @@
   background: rgba(0, 0, 0, 0.5);
   opacity: 0;
   transition: opacity 0.3s;
+  cursor: pointer;
 }
 
 .image-preview:hover .image-preview__btn {
@@ -83,8 +88,8 @@
   background-size: 30px 30px;
   width: 30px;
   height: 30px;
-  cursor: pointer;
 }
+
 
 .upload-label {
   cursor: pointer;
@@ -93,4 +98,8 @@
 .drag-over {
   border: 2px dashed #333;
   background-color: #f0f0f0;
+}
+
+.hidden-destroy-field {
+  display: none !important;
 }

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -5,4 +5,24 @@ class Spot < ApplicationRecord
 
   validates :name, presence: {message: :blank}, length: {maximum: 255}
   validates :description, presence: {message: :blank}, length: {maximum: 65_535}
+
+  validate :must_have_image
+  validate :images_count_within_limit
+
+  private
+
+  def must_have_image
+    # 「_destroyフラグが付いていない画像が0枚ならエラー」
+    if images.reject(&:marked_for_destruction?).empty?
+      errors.add(:images, :blank)
+    end
+  end
+
+  def images_count_within_limit
+    # 同じく _destroy=false の画像が10枚を超えたらエラー
+    valid_images = images.reject(&:marked_for_destruction?)
+    if valid_images.size > 10
+      errors.add(:images, :too_many)
+    end
+  end
 end

--- a/app/views/spots/_form.html.erb
+++ b/app/views/spots/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: spot, local: true, multipart: true,  html: { id: "spot-form", novalidate: true } do |f| %>
+<%= form_with model: spot, local: true, multipart: true, html: { id: "spot-form", novalidate: true } do |f| %>
   <%= render 'shared/error_messages', resource: f.object %>
 
   <%= f.label :name, "スポットネーム", class: "spot_badge" %>
@@ -9,27 +9,56 @@
 
   <div class="form-image">
     <div class="form-image__title">
-      <label for="image-upload", class="spot_badge">スポット画像</label>
+      <label for="image-upload" class="spot_badge">スポット画像</label>
       <div class="form-image__text">最大10枚までアップロードできます</div>
-      <%= f.fields_for :images do |f_img| %>
-        <div class="clearfix">
-          <ul id="previews">
-            <li class="input">
-              <label class="upload-label" for="image-upload">
+
+      <div class="clearfix">
+        <ul id="previews">
+          <!-- 既存画像一覧 -->
+          <% if @spot.persisted? %>
+            <% @spot.images.each.with_index do |image, i| %>
+              <li
+                class="image-preview preview_saved"
+                data-db-id="<%= image.id %>"
+                data-existing-form-index="<%= i %>"
+                data-file-type="existing"
+              >
+                <div class="image-preview__wrapper">
+                  <%= image_tag image.name.url, class: 'existing-spot-image preview' %>
+                  <div class="image-preview__btn">
+                    <button type="button" class="image-preview__btn_delete"></button>
+                  </div>
+                  <!-- ここで fields_for :images, image を使って既存画像を紐付け -->
+                  <%= f.fields_for :images, image do |f_img| %>
+                    <!-- Rails が自動的に hidden name="spot[images_attributes][X][id]" を割り振る -->
+                    <%= f_img.hidden_field :id, class: 'hidden-id-field' %>
+                    <!-- 削除用チェックボックス -->
+                    <%= f_img.check_box :_destroy, class: 'hidden-destroy-field' %>
+                  <% end %>
+                </div>
+              </li>
+            <% end %>
+          <% end %>
+
+          <!-- 新規画像を追加する最初の枠。fields_for で1つだけ空を作っておく -->
+          <% if @spot.images.reject(&:marked_for_destruction?).size < 10 %>
+            <li class="input" data-file-type="new">
+              <label class="upload-label">
                 <div class="upload-label__text">
-                  ドラッグアンドドロップ<br>または<br>クリックしてファイルをアップロード
+                  ドラッグアンドドロップ<br>またはクリックしてファイルをアップロード
                 </div>
                 <div class="input-area">
-                  <%= f_img.file_field :name, class: "hidden image_upload", id: "image-upload" %>
-                  <%= f_img.hidden_field :name_cache %>
+                  <%= f.fields_for :images, @spot.images.build do |fi_new| %>
+                    <%= fi_new.file_field :name, class: "hidden image_upload", multiple: false %>
+                  <% end %>
                 </div>
               </label>
             </li>
-          </ul>
-        </div>
-      <% end %>
+          <% end %>
+        </ul>
+      </div>
     </div>
   </div>
 
-  <%= f.submit "投稿する", class: "btn btn-primary" %>
+  <%= f.submit f.object.persisted? ? "更新する" : "投稿する", class: "btn btn-primary" %>
 <% end %>

--- a/app/views/spots/edit.html.erb
+++ b/app/views/spots/edit.html.erb
@@ -1,2 +1,8 @@
-<h1>Spots#edit</h1>
-<p>Find me in app/views/spots/edit.html.erb</p>
+<div class="container">
+  <div class="row">
+    <div class="col-lg-8 offset-lg-2">
+      <h1><%= t('.edit_title') %></h1>
+      <%= render 'form', { spot: @spot } %>
+    </div>
+  </div>
+</div>

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -24,6 +24,9 @@
           </div>
         <% end %>
       </div>
+    <% if current_user == @spot.user %>
+      <%= link_to '編集する', edit_spot_path(@spot), class: 'btn btn-primary' %>
+    <% end %>
     </div>
   </div>
 </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -7,6 +7,17 @@ ja:
           has_one: "%{record}が存在しているので削除できません"
           has_many: "%{record}が存在しているので削除できません"
       models:
+        spot:
+          attributes:
+            name:
+              blank: "スポット名を入力してください"
+              too_long: "スポット名は%{count}文字以内で入力してください"
+            description:
+              blank: "スポットの説明を入力してください"
+              too_long: "スポットの説明は%{count}文字以内で入力してください"
+            images:
+              blank: "は1枚以上アップロードしてください"
+              too_many: "は10枚までです"
         image:
           attributes:
             name:

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -25,6 +25,8 @@ ja:
       unbookmark: 'ブックマークできませんでした'
       invalid: 'もう一度入力してください'
       spot_success: 'スポットが投稿されました'
+      spot_update: 'スポットが更新されました'
+      spot_not_owner: '編集権限がありません'
     search_word: '検索'
   spot:
     new:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,5 +13,5 @@ Rails.application.routes.draw do
   end
 
   resources :user_informations, only: [:show]
-  resources :spots, only: [:new, :create, :index, :show, :edit]
+  resources :spots, only: [:new, :create, :index, :show, :edit, :update]
 end


### PR DESCRIPTION
## 概要

* 投稿の編集機能を追加し、ユーザーが自身の投稿を更新できるようにしました。
* 既存画像と新規アップロード画像のプレビュー表示に対応し、ユーザー体験を向上させました。
* 認可処理とバリデーションを拡充し、編集権限や画像枚数上限などをより厳密に管理できるようにしました。
* レスポンシブ対応やスタイル調整により、見た目の改善と使いやすさを向上させました。

## 変更点の詳細
### 新機能の追加
#### 投稿編集機能:
* SpotsController に edit と update アクションを実装し、既存の投稿を編集・更新できるようにしました。
* 既存画像 + 新規画像を同時に扱えるようロジックを整理し、インデックスの重複を回避。
* バリデーション強化 (0枚や10枚超過時のエラー、削除済み画像の扱いなど)。

#### 認可処理の強化
* authenticate_user! や require_owner! を導入し、投稿者のみが編集可能になるよう制限。
* ログインしていないユーザーには編集機能を非表示、URL直打ちでもリダイレクトされる仕組みを実装。

#### スタイルとレイアウトの改善
* CSSをレスポンシブ化し、プレビュー領域の幅や画像プレビュー位置を調整。
* 余分なクラスや未使用ロジック (例: adjustInputWidth など) を整理してコードを簡潔化。

#### フラッシュメッセージの翻訳
* エラーメッセージや完了メッセージ (日本語) を config/locales/ja.yml に追加し、国際化対応を強化。