### PR TITLE
スポットの削除機能の実装

### DIFF
--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -1,8 +1,8 @@
 class SpotsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
 
-  before_action :set_spot, only: [:show, :edit, :update]
-  before_action :require_owner!, only: [:edit, :update]
+  before_action :set_spot, only: [:show, :edit, :update, :destroy]
+  before_action :require_owner!, only: [:edit, :update, :destroy]
 
   def index
     @spots = Spot.all
@@ -40,6 +40,15 @@ class SpotsController < ApplicationController
     end
   end
 
+  def destroy
+    if @spot.destroy
+      flash[:notice] = t('defaults.message.spot_destroy')
+      redirect_to root_path
+    else
+      flash[:alert] = t('defaults.message.spot_not_destroy')
+      redirect_to spot_path
+    end
+  end
 
   private
 

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -1,6 +1,5 @@
 class SpotsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-
   before_action :set_spot, only: [:show, :edit, :update, :destroy]
   before_action :require_owner!, only: [:edit, :update, :destroy]
 
@@ -42,11 +41,10 @@ class SpotsController < ApplicationController
 
   def destroy
     if @spot.destroy
-      flash[:notice] = t('defaults.message.spot_destroy')
-      redirect_to root_path
+      # Ajax想定ならflashやリダイレクトではなく、JSONレスポンスなどにする
+      render json: { message: 'Spot was successfully destroyed.' }, status: :ok
     else
-      flash[:alert] = t('defaults.message.spot_not_destroy')
-      redirect_to spot_path
+      render json: { error: 'Failed to destroy.' }, status: :unprocessable_entity
     end
   end
 

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -30,6 +30,7 @@ import './handle_files.js';
 import './spot_drag.js';
 import './spot_form_submission.js';
 import './image_validation.js';
+import './spot_delete.js';
 import 'lightbox2';
 import 'lightbox2/dist/css/lightbox.css';
 import 'lightbox2/dist/js/lightbox.min.js';

--- a/app/javascript/packs/spot_delete.js
+++ b/app/javascript/packs/spot_delete.js
@@ -1,0 +1,34 @@
+import Swal from 'sweetalert2';
+
+$(document).on('turbolinks:load', function() {
+  const csrfToken = $('meta[name="csrf-token"]').attr('content');
+
+  $('.sweet-delete').on('click', function(e) {
+    e.preventDefault();
+    const url = $(this).attr('href');
+
+    Swal.fire({
+      text: '本当に削除しますか？',
+      icon: 'warning',
+      showCancelButton: true,
+      confirmButtonText: 'はい',
+      cancelButtonText: 'いいえ'
+    }).then((result) => {
+      if (result.isConfirmed) {
+        $.ajax({
+          url: url,
+          type: 'DELETE',
+          headers: {
+            'X-CSRF-Token': csrfToken
+          }
+        }).done(function() {
+          Swal.fire('削除完了', '削除が完了しました', 'success').then(() => {
+            window.location.href = '/spots';
+          });
+        }).fail(function() {
+          Swal.fire('エラー', '削除に失敗しました', 'error');
+        });
+      }
+    });
+  });
+});

--- a/app/javascript/stylesheets/styles.scss
+++ b/app/javascript/stylesheets/styles.scss
@@ -2877,6 +2877,7 @@ textarea.form-control-lg {
   --bs-btn-disabled-color: #fff;
   --bs-btn-disabled-bg: #6c757d;
   --bs-btn-disabled-border-color: #6c757d;
+  margin-top: 10px;
 }
 
 .btn-success {
@@ -2894,6 +2895,7 @@ textarea.form-control-lg {
   --bs-btn-disabled-color: #fff;
   --bs-btn-disabled-bg: #198754;
   --bs-btn-disabled-border-color: #198754;
+  margin-top: 10px;
 }
 
 .btn-info {
@@ -2928,6 +2930,7 @@ textarea.form-control-lg {
   --bs-btn-disabled-color: #fff;
   --bs-btn-disabled-bg: #ffc800;
   --bs-btn-disabled-border-color: #ffc800;
+  margin-top: 10px;
 }
 
 .btn-danger {
@@ -2945,6 +2948,7 @@ textarea.form-control-lg {
   --bs-btn-disabled-color: #fff;
   --bs-btn-disabled-bg: #dc3545;
   --bs-btn-disabled-border-color: #dc3545;
+  margin-top: 10px;
 }
 
 .btn-light {
@@ -2962,6 +2966,7 @@ textarea.form-control-lg {
   --bs-btn-disabled-color: #000;
   --bs-btn-disabled-bg: #f8f9fa;
   --bs-btn-disabled-border-color: #f8f9fa;
+  margin-top: 10px;
 }
 
 .btn-dark {
@@ -2979,6 +2984,7 @@ textarea.form-control-lg {
   --bs-btn-disabled-color: #fff;
   --bs-btn-disabled-bg: #212529;
   --bs-btn-disabled-border-color: #212529;
+  margin-top: 10px;
 }
 
 .btn-outline-primary {

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -13,7 +13,7 @@
       }
     }
 
-    $(document).on('turbolinks:load', function() {
+    function showFlashMessages() {
       <% flash.each do |message_type, message| %>
         Swal.fire({
           icon: getIconByType("<%= message_type %>"),
@@ -24,7 +24,10 @@
           timer: 5000
         });
       <% end %>
-    });
+    }
+
+    document.addEventListener('DOMContentLoaded', showFlashMessages);
+
+    document.addEventListener('turbolinks:load', showFlashMessages);
   </script>
 <% end %>
-

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -26,6 +26,7 @@
       </div>
     <% if current_user == @spot.user %>
       <%= link_to '編集する', edit_spot_path(@spot), class: 'btn btn-primary' %>
+      <%= link_to '削除する', spot_path(@spot), class: 'btn btn-danger sweet-delete' %>
     <% end %>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,5 +13,5 @@ Rails.application.routes.draw do
   end
 
   resources :user_informations, only: [:show]
-  resources :spots, only: [:new, :create, :index, :show, :edit, :update]
+  resources :spots, only: [:new, :create, :index, :show, :edit, :update, :destroy]
 end


### PR DESCRIPTION
## 概要

* 投稿の削除機能を追加し、ユーザーが自身の投稿を安全に削除できるようにしました。
* 削除時に SweetAlert2 を用いたダイアログを表示することで、操作確認をスムーズに行えるように改善。
* 認可処理で投稿者本人のみが削除可能になるよう制限し、セキュリティを強化。

## 変更点の詳細
### 新機能の追加
#### 投稿削除機能:
* resources :spots に :destroy を追加し、SpotsController に destroy アクションを実装。
* CSRF トークンを付与した AJAX リクエストで安全に投稿を削除。
* before_action :require_owner! により、投稿者のみ削除可。

#### 削除前のダイアログ表示 (SweetAlert2)
* 削除ボタン (.sweet-delete) をクリックした際に SweetAlert2 で確認ダイアログを表示。
  * 「はい」を選択すると実際に DELETE リクエストを送信。
  * 成功時はトースト通知を表示し、一覧画面 (/spots) へ移動。
  * 失敗時にはエラーメッセージを表示。
* Rails 側では JSON レスポンスを返し、画面遷移やフラッシュメッセージはフロントで制御。

#### フラッシュメッセージの表示改善
* Turbolinks 部分リロード時にもフラッシュメッセージが出るようにイベントを拡充。
