### PR TITLE
ドラッグ&ドロップした画像の保存対応 & エラーメッセージの文言修正

### DIFF
--- a/app/javascript/packs/spot_drag.js
+++ b/app/javascript/packs/spot_drag.js
@@ -3,7 +3,6 @@ import { handleFiles } from './handle_files';
 $(document).on('turbolinks:load', function() {
   const dropArea = $('#previews');
 
-  // ドラッグ関連のイベントを解除して重複を防ぐ
   dropArea.off('dragover dragleave drop');
 
   dropArea.on('dragover', function(event) {
@@ -20,9 +19,24 @@ $(document).on('turbolinks:load', function() {
 
   dropArea.on('drop', function(event) {
     event.preventDefault();
+    event.stopPropagation();
+    dropArea.removeClass('drag-over');
+
     const files = event.originalEvent.dataTransfer.files;
+
     if (files.length) {
-      handleFiles(files, $('#previews .input').first(), $('#previews .input').first().find('.upload-label'));
+      const $li = $('#previews .input').first();
+      const $label = $li.find('.upload-label');
+      const input = $li.find('input.image_upload')[0];
+
+      const dt = new DataTransfer();
+      for (let i = 0; i < files.length; i++) {
+        dt.items.add(files[i]);
+      }
+
+      input.files = dt.files;
+
+      handleFiles(files, $li, $label);
     }
   });
 });

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -16,8 +16,8 @@ ja:
               blank: "スポットの説明を入力してください"
               too_long: "スポットの説明は%{count}文字以内で入力してください"
             images:
-              blank: "は1枚以上アップロードしてください"
-              too_many: "は10枚までです"
+              blank: "画像は1枚以上アップロードしてください"
+              too_many: "画像は10枚までです"
         image:
           attributes:
             name:


### PR DESCRIPTION
## 概要

* ドラッグ&ドロップ機能を拡張し、ドロップした画像を input.files に直接代入して送信できるようにしました。
* ja.yml のエラーメッセージに足りなかった「画像」の文言を追加し、ユーザーに分かりやすい表示に修正しました。

## 変更点の詳細
### 機能の追加
#### ドラッグ&ドロップ機能の保存対応
* DataTransfer を用いてドロップされた画像を input.files に手動で代入。
* handle_files.js を呼び出してプレビューが生成されるように連携。

#### エラーメッセージの文言修正
* 「は1枚以上アップロードしてください」→「画像は1枚以上アップロードしてください」に変更。
* 「は10枚までです」→「画像は10枚までです」に変更。
* ユーザーがアップロード時に直感的に理解できる表記に改善。