### PR TITLE
Turbolinks遷移でのフラッシュ多重表示を解消し、表示ロジックをpacksへ集約（SweetAlert2によるトースト表示に統一）

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -35,6 +35,7 @@ import 'lightbox2';
 import 'lightbox2/dist/css/lightbox.css';
 import 'lightbox2/dist/js/lightbox.min.js';
 import './delete_spots_confirmation.js';
+import './flash_messages';
 
 function bootMap() {
   const map = document.getElementById('map');

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -17,9 +17,6 @@ require("bootstrap");
 const images = require.context('../images', true)
 const imagePath = (name) => images(name, true)
 
-import Swal from 'sweetalert2'
-window.Swal = Swal
-
 import 'bootstrap'
 import "../stylesheets/application.scss";
 import '@fortawesome/fontawesome-free/js/all';

--- a/app/javascript/packs/flash_messages.js
+++ b/app/javascript/packs/flash_messages.js
@@ -1,7 +1,7 @@
-/* flash_messages.js */
 import Swal from 'sweetalert2';
 
 const FLASH_SELECTOR = '.js-flash-message';
+const FLASH_CONTAINER_ID = 'flash-messages';
 
 /** Bootstrap/Deviseの種別→SweetAlert2アイコンへ */
 const iconByType = (type) => {
@@ -19,10 +19,22 @@ const iconByType = (type) => {
   }
 };
 
-/** 表示してからノードを消す（BFCache復帰での再実行を防止） */
+/** フラッシュ用のDOMを一括掃除（ノードとコンテナの両方） */
+const removeFlashDom = () => {
+  document.querySelectorAll(FLASH_SELECTOR).forEach((node) => node.remove());
+  const container = document.getElementById(FLASH_CONTAINER_ID);
+  if (container) container.remove();
+};
+
+/** 表示してからDOMを掃除（BFCache復帰や再実行を防止） */
 const showFlashMessages = () => {
   const nodes = document.querySelectorAll(FLASH_SELECTOR);
-  if (!nodes.length) return;
+
+  // 0件でも掃除は実施（残存コンテナ対策）
+  if (!nodes.length) {
+    removeFlashDom();
+    return;
+  }
 
   nodes.forEach((node) => {
     const type = node.dataset.flashType;
@@ -37,21 +49,14 @@ const showFlashMessages = () => {
       showConfirmButton: false,
       timer: 5000
     });
-
-    node.remove();
   });
 
-  const container = document.getElementById('flash-messages');
-  if (container) container.remove();
+  // 表示直後に必ず掃除（このページでの再表示を防止）
+  removeFlashDom();
 };
 
-/** TurbolinksのBFCacheに入る前に掃除 */
-const cleanupBeforeCache = () => {
-  document.querySelectorAll(FLASH_SELECTOR).forEach((n) => n.remove());
-  const container = document.getElementById('flash-messages');
-  if (container) container.remove();
-};
+/** TurbolinksのBFCacheに入る前にも念のため掃除 */
+document.addEventListener('turbolinks:before-cache', removeFlashDom);
 
-/** イベント登録（Turbolinks前提。DOMContentLoadedは不要） */
+/** Turbolinks前提。DOMContentLoadedは不要 */
 document.addEventListener('turbolinks:load', showFlashMessages);
-document.addEventListener('turbolinks:before-cache', cleanupBeforeCache);

--- a/app/javascript/packs/flash_messages.js
+++ b/app/javascript/packs/flash_messages.js
@@ -1,0 +1,57 @@
+/* flash_messages.js */
+import Swal from 'sweetalert2';
+
+const FLASH_SELECTOR = '.js-flash-message';
+
+/** Bootstrap/Deviseの種別→SweetAlert2アイコンへ */
+const iconByType = (type) => {
+  switch (String(type)) {
+    case 'success':
+    case 'notice':
+      return 'success';
+    case 'danger':
+    case 'alert':
+      return 'error';
+    case 'warning':
+      return 'warning';
+    default:
+      return 'info';
+  }
+};
+
+/** 表示してからノードを消す（BFCache復帰での再実行を防止） */
+const showFlashMessages = () => {
+  const nodes = document.querySelectorAll(FLASH_SELECTOR);
+  if (!nodes.length) return;
+
+  nodes.forEach((node) => {
+    const type = node.dataset.flashType;
+    const message = node.dataset.flashMessage;
+    if (!message) return;
+
+    Swal.fire({
+      icon: iconByType(type),
+      title: message,
+      toast: true,
+      position: 'top',
+      showConfirmButton: false,
+      timer: 5000
+    });
+
+    node.remove();
+  });
+
+  const container = document.getElementById('flash-messages');
+  if (container) container.remove();
+};
+
+/** TurbolinksのBFCacheに入る前に掃除 */
+const cleanupBeforeCache = () => {
+  document.querySelectorAll(FLASH_SELECTOR).forEach((n) => n.remove());
+  const container = document.getElementById('flash-messages');
+  if (container) container.remove();
+};
+
+/** イベント登録（Turbolinks前提。DOMContentLoadedは不要） */
+document.addEventListener('turbolinks:load', showFlashMessages);
+document.addEventListener('turbolinks:before-cache', cleanupBeforeCache);

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,33 +1,9 @@
+<%# フラッシュがある時だけ、データノードを出力 %>
 <% if flash.present? %>
-  <script>
-    function getIconByType(type) {
-      switch(type) {
-        case 'success':
-        case 'notice':
-          return 'success';
-        case 'danger':
-        case 'alert':
-          return 'error';
-        default:
-          return 'info';
-      }
-    }
-
-    function showFlashMessages() {
-      <% flash.each do |message_type, message| %>
-        Swal.fire({
-          icon: getIconByType("<%= message_type %>"),
-          title: "<%= j message %>",
-          toast: true,
-          position: 'top',
-          showConfirmButton: false,
-          timer: 5000
-        });
-      <% end %>
-    }
-
-    document.addEventListener('DOMContentLoaded', showFlashMessages);
-
-    document.addEventListener('turbolinks:load', showFlashMessages);
-  </script>
+  <div id="flash-messages" aria-live="polite" class="sr-only"></div>
+  <% flash.each do |type, message| %>
+    <div class="js-flash-message"
+         data-flash-type="<%= type %>"
+         data-flash-message="<%= j message %>"></div>
+  <% end %>
 <% end %>


### PR DESCRIPTION
## 概要

* フラッシュメッセージの表示処理を ビュー(ERB) から packs側のJS(webpackerで束ねたスクリプト) に移管（責務分離(役割分担を明確化)）
* Turbolinks（高速遷移ライブラリ）環境で発生していた、ページ遷移後も同じフラッシュが再表示される不具合を解消
* 表示は SweetAlert2 の toast（トースト通知/画面隅の軽量通知）に統一し、UIの一貫性を向上
* アクセシビリティ改善のため、コンテナに aria-live="polite"（支援技術への控えめな読み上げ指示）と sr-only（視覚非表示/スクリーンリーダー向け）を付与

## 変更点の詳細

### ビュー（部分テンプレート）の見直し
- `views/shared/_flash_message.html.erb`
  - 表示ロジック(JS)を撤去し、**データノードのみ**を出力
    - `<div class="js-flash-message" data-flash-type data-flash-message>` をフラッシュ件数分生成
    - `data-flash-message` には `<%= j message %>` を適用し、JS向けに安全にエスケープ
  - コンテナに `id="flash-messages"`, `aria-live="polite"`, `class="sr-only"` を付与（A11y）
### packs 側に表示ロジックを集約
- `app/javascript/packs/flash_messages.js`（新規）
  - `turbolinks:load` で `.js-flash-message` を走査 → **SweetAlert2 toast** を表示 → **直後にノードを remove()**
  - `turbolinks:before-cache` でノード/コンテナを掃除し、**BFCache（戻る/進む）時の二重表示を防止**
  - ネイティブDOMに“イベント名前空間”は使用しない（jQuery固有機能のため）
  - `DOMContentLoaded` は未使用（Turbolinksでは `turbolinks:load` で十分）

### エントリーポイント
- `app/javascript/packs/application.js`
  - `import './flash_messages'` を追加（読み込み点を一本化）
  - SweetAlert2 の import 位置の重複を排除し、読み込み方針を統一

## 動作確認
- ログイン直後に **1回だけ** トーストが表示されること
- そのまま別ページへ遷移しても **再表示されない** こと
- ブラウザの **戻る/進む（BFCache）** でも **再表示されない** こと
- `notice / alert / warning` がそれぞれ `success / error / warning` アイコンに正しくマッピングされること

## 補足（設計意図）
- **責務分離**：ビュー=データ埋め込み、JS=表示に分離（保守性・可読性の向上）
- **再表示防止の二段構え**：表示直後の **node.remove()** + **before-cache の掃除**
- **安全な文字列受け渡し**：`<%= j message %>` により、引用符・改行を含む文言もJSとして安全に受け渡し

## レビューによる追加の変更点
- **DOM掃除を関数抽出**：`removeFlashDom()` を新設し、`.js-flash-message` と `#flash-messages` の削除処理を共通化（DRY）
- **IDの単一情報源化**：`FLASH_CONTAINER_ID = 'flash-messages'` を導入し、直書きを排除
- **0件時も掃除**：フラッシュ要素が存在しない場合でも `removeFlashDom()` を実行し、残存コンテナを確実に除去
- **一括掃除に統一**：ループ内の個別 `node.remove()` をやめ、**表示後に一括で `removeFlashDom()`** を実行（見通し・保守性の向上）
- **イベント簡素化**：`turbolinks:before-cache` へは **`removeFlashDom` を直接バインド**（薄いラッパ関数を削除）
- **import方針の統一**：`application.js` から `import Swal` / `window.Swal` を削除し、**各モジュールでの局所import** に一本化